### PR TITLE
frontpage에서 top-banner가 body영역을 넘어서는 문제 해결

### DIFF
--- a/css/tossdev.css
+++ b/css/tossdev.css
@@ -185,6 +185,9 @@ margin:0px 0 0; /* negative fixed header height */
             color: #4e7bfa;
 */
         }
+    #frontpage .top-banner .row {
+        margin: 0;
+    }
 
 /* media queries for 'front page' */
     @media screen and (max-width: 580px) {


### PR DESCRIPTION
`.row`는 좌우로 -15px의 margin을 가지는데 상위 element가 적합한 padding을 가지지 않아 문제되던 곳의 margin값을 0으로 설정했습니다.