### PR TITLE
chore(tosspay-guide-page): 토스페이 연동 가이드 페이지 로고를 변경한다

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,14 +113,15 @@
     <!-- End Google Tag Manager -->
 
     <nav id="header">
-      <div class="logo">
-        <img
-          class="logo-img"
-          src="https://static.toss.im/tds/icon/svg/logo-only-icon.svg"
-          alt=""
-        />
-        <span>결제 연동 가이드</span>
-      </div>
+      <a href="https://pay.toss.im/pay">
+        <div class="logo">
+          <img
+            class="logo-img"
+            src="https://static.toss.im/logos/svg/logo-toss-pay.svg"
+            alt=""
+          />
+        </div>
+      </a>
       <div class="header-menu">
         <a
           class="button button button--size-medium"
@@ -139,13 +140,7 @@
             예제 코드까지, 친절하게 안내해드립니다.
           </p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button--style-weak button--type-dark button--size-medium"
             href="gettingstarted.html"
             >보기</a
           >
@@ -157,13 +152,7 @@
             각 API에 대한 상세한 설명을 조회할 수 있습니다.
           </p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button button--style-weak button--type-dark button--size-medium"
             href="api.html"
             >보기</a
           >
@@ -176,13 +165,7 @@
           <h3>토스페이 데모</h3>
           <p>직접 토스페이를 경험해보세요. <br /></p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button button--style-weak button--type-dark button--size-medium"
             href="https://pay.toss.im/payfront/demo/payments"
             >해보기</a
           >
@@ -195,13 +178,7 @@
             안내 드립니다. 궁금하신 사항을 확인해보세요.
           </p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button--style-weak button--type-dark button--size-medium"
             href="qna.html"
             >보기</a
           >
@@ -217,13 +194,7 @@
             상세 정책을 확인하세요.
           </p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button--style-weak button--type-dark button--size-medium"
             href="policy.html"
             >보기</a
           >
@@ -235,13 +206,7 @@
             가이드를 활용하세요.
           </p>
           <a
-            class="
-              button
-              button
-              button--style-weak
-              button--type-dark
-              button--size-medium
-            "
+            class="button button--style-weak button--type-dark button--size-medium"
             href="https://static.toss.im/assets/pay/files/Toss_BrandKit_public.zip"
             download
             >다운로드</a


### PR DESCRIPTION
## 작업내용

- 토스페이 연동 가이드 페이지의 로고를 변경합니다.
- 로고 클릭 시, 토스페이 메인 홈페이지로 이동하도록 수정합니다.
- 요소에 중복으로 사용된 클래스명(button)을 제거합니다.

### AS-IS

<img width="2283" alt="image" src="https://user-images.githubusercontent.com/26535030/210211522-d4d5afd7-36ab-4cf1-9985-f8d791381c15.png">


### TO-BE

<img width="2559" alt="image" src="https://user-images.githubusercontent.com/26535030/210211547-a7666e3c-79d2-4ca5-8d4b-5d40a93ab9fb.png">

### 노션 링크 (토스페이 리뉴얼 QA 문서)

- https://www.notion.so/tossteam/c451a665c4f447bea77795f7ffa47d70
